### PR TITLE
unwrap optional so that 2.3 swift compile xCode8

### DIFF
--- a/Source/FAIcon.swift
+++ b/Source/FAIcon.swift
@@ -306,15 +306,16 @@ private class FontLoader {
                 }
                 let data = NSData(contentsOfURL: fontURL)!
                 
-                let provider = CGDataProviderCreateWithCFData(data)
-                let font = CGFontCreateWithDataProvider(provider)!
-                
-                var error: Unmanaged<CFError>?
-                if !CTFontManagerRegisterGraphicsFont(font, &error) {
+                if let provider = CGDataProviderCreateWithCFData(data) {
+                    let font = CGFontCreateWithDataProvider(provider)!
                     
-                    let errorDescription: CFStringRef = CFErrorCopyDescription(error!.takeUnretainedValue())
-                    let nsError = error!.takeUnretainedValue() as AnyObject as! NSError
-                    NSException(name: NSInternalInconsistencyException, reason: errorDescription as String, userInfo: [NSUnderlyingErrorKey: nsError]).raise()
+                    var error: Unmanaged<CFError>?
+                    if !CTFontManagerRegisterGraphicsFont(font, &error) {
+                        
+                        let errorDescription: CFStringRef = CFErrorCopyDescription(error!.takeUnretainedValue())
+                        let nsError = error!.takeUnretainedValue() as AnyObject as! NSError
+                        NSException(name: NSInternalInconsistencyException, reason: errorDescription as String, userInfo: [NSUnderlyingErrorKey: nsError]).raise()
+                    }
                 }
             }
         }

--- a/Source/FAIcon.swift
+++ b/Source/FAIcon.swift
@@ -307,7 +307,7 @@ private class FontLoader {
                 let data = NSData(contentsOfURL: fontURL)!
                 
                 if let provider = CGDataProviderCreateWithCFData(data) {
-                    let font = CGFontCreateWithDataProvider(provider)!
+                    let font = CGFontCreateWithDataProvider(provider)
                     
                     var error: Unmanaged<CFError>?
                     if !CTFontManagerRegisterGraphicsFont(font, &error) {


### PR DESCRIPTION
This is for people who would like to do a Swift Syntax conversion for Swift 2.3  NOT 3.0

it would be nice to have this released so that users not ready to migrate to Swift 3 yet can
pod 'Font-Awesome-Swift', 'x.x.x'  
and easily migrate
