### PR TITLE
Update FAIcon.swift

### DIFF
--- a/Source/FAIcon.swift
+++ b/Source/FAIcon.swift
@@ -329,7 +329,7 @@ public enum FAType: Int {
     }
     
     
-    var text: String? {
+    public var text: String? {
         
         return FAIcons[rawValue]
     }


### PR DESCRIPTION
As it's a readonly property it won't hurt to make it accessible and it comes in handy in certain cases where the attributes and the text are setup through different properties on UIKit elements
e.g.
```
    let tittleAttProvider = UIBarButtonItem()
    tittleAttProvider.setFAIcon(icon: self.icons[index], iconSize: 35)
    navigationBar.titleTextAttributes = tittleAttProvider.titleTextAttributes(for: .normal) 
    let navigationItem = UINavigationItem(title: self.icons[index].text!)
```