### PR TITLE
Fix: UITabBarItem color options not working https://github.com/Vabere…

### DIFF
--- a/Source/FAIcon.swift
+++ b/Source/FAIcon.swift
@@ -225,8 +225,13 @@ public extension UITabBarItem {
     public func setFAIcon(icon: FAType, size: CGSize? = nil, textColor: UIColor = UIColor.black, backgroundColor: UIColor = UIColor.clear, selectedTextColor: UIColor = UIColor.black, selectedBackgroundColor: UIColor = UIColor.clear) {
         FontLoader.loadFontIfNeeded()
         let tabBarItemImageSize = size ?? CGSize(width: 30, height: 30)
-        image = UIImage(icon: icon, size: tabBarItemImageSize, textColor: textColor, backgroundColor: backgroundColor)
-        selectedImage = UIImage(icon: icon, size: tabBarItemImageSize, textColor: selectedTextColor, backgroundColor: selectedBackgroundColor)
+        
+        image = UIImage(icon: icon, size: tabBarItemImageSize, textColor: textColor, backgroundColor: backgroundColor).withRenderingMode(UIImageRenderingMode.alwaysOriginal)
+        
+        selectedImage = UIImage(icon: icon, size: tabBarItemImageSize, textColor: selectedTextColor, backgroundColor: selectedBackgroundColor).withRenderingMode(UIImageRenderingMode.alwaysOriginal)
+        
+        setTitleTextAttributes([NSForegroundColorAttributeName: textColor], for: .normal)
+        setTitleTextAttributes([NSForegroundColorAttributeName: selectedTextColor], for: .selected)
     }
 }
 


### PR DESCRIPTION
Fix for https://github.com/Vaberer/Font-Awesome-Swift/issues/69: UITabBarItem color options not working

With this fix you can correctly set the color of the FA icon and text when using `tabBarItem.setFAIcon`

