### PR TITLE
Remove empty string initializer on UIButton color

### DIFF
--- a/Source/FAIcon.swift
+++ b/Source/FAIcon.swift
@@ -139,8 +139,7 @@ public extension UIButton {
     func setFATitleColor(color: UIColor, forState state: UIControlState = .normal) {
         FontLoader.loadFontIfNeeded()
  
-        let emptyString = " "
-        let attributedString = NSMutableAttributedString(attributedString: attributedTitle(for: state) ?? NSAttributedString(string: emptyString))
+        let attributedString = NSMutableAttributedString(attributedString: attributedTitle(for: state) ?? NSAttributedString())
         attributedString.addAttribute(NSForegroundColorAttributeName, value: color, range: NSMakeRange(0, attributedString.length))
        
         setAttributedTitle(attributedString, for: state)


### PR DESCRIPTION
This fixed a bug for me where setting the FAIcon via `setFAIcon` for a `UIButton` and then subsequently trying to set the color with `setFATitleColor` would cause the icon to disappear from the `UIButton`.  This was due to the empty attributed string in `func setFATitleColor(color: UIColor, forState state: UIControlState = .normal)` which included a space (" ") that ultimately covers the original icon.

This breaks between versions 1.6.1 to 1.6.2

Commit notes:
Remove empty string initializer on UIButton FA Title color setting which caused icons on UIButtons to disappear if previously set with setFAIcon.

